### PR TITLE
Chore/update versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gem 'danger'
 # Add a danger plugin if necessary.
 gem 'danger-lgtm'
 gem 'danger-todoist'
+
+# for security patch
+gem "kramdown", ">= 2.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
-    claide (1.0.2)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    claide (1.0.3)
     claide-plugins (0.9.2)
       cork
       nap
@@ -11,15 +11,16 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.6.4)
+    danger (7.0.1)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
       cork (~> 0.1)
-      faraday (~> 0.9)
-      faraday-http-cache (~> 1.0)
-      git (~> 1)
-      kramdown (~> 1.5)
+      faraday (>= 0.9.0, < 2.0)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.7)
+      kramdown (~> 2.0)
+      kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
@@ -29,25 +30,32 @@ GEM
       danger (> 2.0)
     danger-todoist (1.2.3)
       danger-plugin-api (~> 1.0)
-    faraday (0.15.2)
+    faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (1.3.1)
-      faraday (~> 0.8)
-    git (1.3.0)
-    kramdown (1.17.0)
-    multipart-post (2.0.0)
+    faraday-http-cache (2.2.0)
+      faraday (>= 0.8)
+    git (1.7.0)
+      rchardet (~> 1.8)
+    kramdown (2.3.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    octokit (4.12.0)
+    octokit (4.18.0)
+      faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    public_suffix (3.0.3)
-    sawyer (0.8.1)
-      addressable (>= 2.3.5, < 2.6)
-      faraday (~> 0.8, < 1.0)
+    public_suffix (4.0.5)
+    rchardet (1.8.0)
+    rexml (3.2.4)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -58,4 +66,4 @@ DEPENDENCIES
   danger-todoist
 
 BUNDLED WITH
-   1.16.4
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ DEPENDENCIES
   danger
   danger-lgtm
   danger-todoist
+  kramdown (>= 2.3.0)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
## やったこと
- dangerのバージョンアップ
  - 最新は8だが、ruby2.4以降しか対応していないので6→7
- kramdownのセキュリティアラートが出ていたので更新

- https://github.com/f-scratch/fs-goutil/pull/2#issuecomment-673331309 のdangerのエラーを解消したい