### PR TITLE
fix: fix bundler version & remove unnecessary context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
             docker push ${DOCKERHUB_ORG_NAME}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_TAG}
             docker push ${DOCKERHUB_ORG_NAME}/${CIRCLE_PROJECT_REPONAME}:latest
             curl -X POST https://hooks.microbadger.com/images/${DOCKERHUB_ORG_NAME}/${CIRCLE_PROJECT_REPONAME}/7Lgm9UVdeKKqwGjSiqoVssAEuOc=
-            
+
 workflows:
   version: 2
   build-and-deploy:
@@ -78,9 +78,8 @@ workflows:
       - build_container:
           filters:
             tags:
-              only: /^v[0-9]+(\.[0-9]+)*(-.*)*/ 
+              only: /^v[0-9]+(\.[0-9]+)*(-.*)*/
       - push_container:
-          context: container-registory
           requires:
             - build_container
           filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ COPY --chown=circleci:circleci Dangerfile $HOME/danger/
 
 WORKDIR $HOME/danger
 
-RUN gem install bundler --no-document && \
-    bundle install
+RUN gem install bundler -v 1.17.3 --no-document && \
+    bundle _1.17.3_ install
 
 CMD ["/bin/sh"]


### PR DESCRIPTION
## やったこと
- bundler のバージョンを1系に固定 (2系でbundle installされると1系を使ってる時に落ちて面倒なので)
  - [これ](https://app.circleci.com/pipelines/github/f-scratch/fs-goutil/23/workflows/41598a7c-01ab-4dc1-b810-c651f6413878/jobs/112)で `You must use Bundler 2 or greater with this lockfile.` が発生していた
- 使用してないcontextを削除