### PR TITLE
upgrade danger version8.4.0

### DIFF
--- a/Dangerfile4th
+++ b/Dangerfile4th
@@ -1,2 +1,2 @@
 # Change to the path of the dangerfile you want to import.
-danger.import_dangerfile(github: "f-scratch/dangerfile", branch: "master", path: "Dangerfile4th")
+danger.import_dangerfile(github: "f-scratch/dangerfile", branch: "feat/add_circleci", path: "Dangerfile4th")

--- a/Dangerfile4th
+++ b/Dangerfile4th
@@ -1,2 +1,2 @@
 # Change to the path of the dangerfile you want to import.
-danger.import_dangerfile(github: "f-scratch/dangerfile", branch: "feat/ruby_2.7.1_danger_8.4.0", path: "Dangerfile4th")
+danger.import_dangerfile(github: "f-scratch/dangerfile", branch: "master", path: "Dangerfile4th")

--- a/Dangerfile4th
+++ b/Dangerfile4th
@@ -1,2 +1,2 @@
 # Change to the path of the dangerfile you want to import.
-danger.import_dangerfile(github: "f-scratch/dangerfile", branch: "feat/add_circleci", path: "Dangerfile4th")
+danger.import_dangerfile(github: "f-scratch/dangerfile", branch: "feat/ruby_2.7.1_danger_8.4.0", path: "Dangerfile4th")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1-alpine
+FROM ruby:2.7.1-alpine
 
 ARG VCS_REF
 ARG BUILD_DATE
@@ -23,7 +23,7 @@ COPY --chown=circleci:circleci Dangerfile4th $HOME/danger/
 
 WORKDIR $HOME/danger
 
-RUN gem install bundler -v 1.17.3 --no-document && \
-    bundle _1.17.3_ install
+RUN gem install bundler --no-document && \
+    bundle install
 
 CMD ["/bin/sh"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     unicode-display_width (2.1.0)
 
 PLATFORMS
-  x86_64-linux-musl
+  ruby
 
 DEPENDENCIES
   danger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     claide (1.0.3)
     claide-plugins (0.9.2)
@@ -11,7 +11,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (7.0.1)
+    danger (8.4.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -19,46 +19,64 @@ GEM
       faraday (>= 0.9.0, < 2.0)
       faraday-http-cache (~> 2.0)
       git (~> 1.7)
-      kramdown (~> 2.0)
+      kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
       octokit (~> 4.7)
-      terminal-table (~> 1)
+      terminal-table (>= 1, < 4)
     danger-lgtm (1.1.1)
       danger-plugin-api (~> 1.0)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
-    danger-todoist (1.3.0)
+    danger-todoist (2.0.1)
       danger-plugin-api (~> 1.0)
-    faraday (1.0.1)
+    faraday (1.8.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
     faraday-http-cache (2.2.0)
       faraday (>= 0.8)
-    git (1.7.0)
+    faraday-httpclient (1.0.1)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    git (1.9.1)
       rchardet (~> 1.8)
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    octokit (4.19.0)
+    octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
     public_suffix (4.0.6)
     rchardet (1.8.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
+    ruby2_keywords (0.0.5)
     sawyer (0.8.2)
       addressable (>= 2.3.5)
       faraday (> 0.8, < 2.0)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
-    unicode-display_width (1.7.0)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux-musl
 
 DEPENDENCIES
   danger
@@ -67,4 +85,4 @@ DEPENDENCIES
   kramdown (>= 2.3.0)
 
 BUNDLED WITH
-   1.17.3
+   2.2.28


### PR DESCRIPTION
## 目的
- 概要
danger バージョンを8.4.0にアップグレード

- 関連リンク
none

## 対応分類
- [x] 追加 
- [ ] 変更
- [ ] 削除

## やったこと
1. 【変更】以下のエラーが出てDanger versionのアップグレードが要求されたため、バージョンを8.xにアップグレードする。アップグレード伴い、rubyのバージョンが2.4以上を要求されるため、dockerのrubyバージョンも2.7.1にあげてます。

https://app.circleci.com/pipelines/github/f-scratch/zelda-vortex4th/3174/workflows/bae3c5c5-c14c-49cd-ad82-b5ac8992f4df/jobs/11883

## 残課題
なし

## 影響範囲調査結果
1. 追加のみで既存影響はvortex-batchのデプロイ操作全般
